### PR TITLE
gh-124 apparently godot uses shallow copies for arrays by default, so…

### DIFF
--- a/src/Scripts/Game.gd
+++ b/src/Scripts/Game.gd
@@ -8,7 +8,7 @@ var mob_packs = []
 var mob_pack_index = 0
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	mob_packs = EnemyPacks.mob_packs
+	mob_packs = EnemyPacks.mob_packs.duplicate(true)
 	score = -1
 	_on_score_increase()
 	SignalManager.connect("score_increase", _on_score_increase)


### PR DESCRIPTION
… the first game was consuming the mob_packs array. Is fixed.